### PR TITLE
Test  disable conjured items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A small inn with a prime location and some bad code.",
   "scripts": {
     "test": "jest",
+    "test:coverage": "jest --coverage=true",
     "lint": "eslint ./ --ignore-path .gitignore"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A small inn with a prime location and some bad code.",
   "scripts": {
-    "test": "echo 'Hellllooo? Anyone there?'",
+    "test": "jest",
     "lint": "eslint ./ --ignore-path .gitignore"
   },
   "repository": {

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -38,4 +38,20 @@ describe('`updateQuality`', () => {
     expect(passPostConcert.quality).toBe(0)
     expect(passMinimumQuality.quality).toBe(0)
   })
+
+  it('Updates the quality of normal items', () => {
+    const vest = new Item('+5 Dexterity Vest', 5, 10)
+    const oldVest = new Item('+5 Dexterity Vest', -1, 5)
+    const minimumQualityVest = new Item('+5 Dexterity Vest', -5, 0)
+    const elixir = new Item('Elixir of the Mongoose', 3, 50)
+    const oldElixir = new Item('Elixir of the Mongoose', 0, 28)
+    const minimumQualityElixir = new Item('Elixir of the Mongoose', 0, 0)
+    updateQuality([vest, oldVest, minimumQualityVest, elixir, oldElixir, minimumQualityElixir])
+    expect(vest.quality).toBe(9)
+    expect(oldVest.quality).toBe(3)
+    expect(minimumQualityVest.quality).toBe(0)
+    expect(elixir.quality).toBe(49)
+    expect(oldElixir.quality).toBe(26)
+    expect(minimumQualityElixir.quality).toBe(0)
+  })
 });

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -22,4 +22,20 @@ describe('`updateQuality`', () => {
     updateQuality([sulfuras]);
     expect(sulfuras.quality).toBe(50);
   })
+
+  it('Updates the quality of backstage passes', () => {
+    const pass = new Item('Backstage passes to a TAFKAL80ETC concert', 11, 10)
+    const passTenDays = new Item('Backstage passes to a TAFKAL80ETC concert', 10, 8)
+    const passFiveDays = new Item('Backstage passes to a TAFKAL80ETC concert', 5, 15)
+    const passMaximumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', 1, 50)
+    const passPostConcert = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 50)
+    const passMinimumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 0)
+    updateQuality([pass, passTenDays, passFiveDays, passMaximumQuality, passPostConcert, passMinimumQuality])
+    expect(pass.quality).toBe(11)
+    expect(passTenDays.quality).toBe(10)
+    expect(passFiveDays.quality).toBe(18)
+    expect(passMaximumQuality.quality).toBe(50)
+    expect(passPostConcert.quality).toBe(0)
+    expect(passMinimumQuality.quality).toBe(0)
+  })
 });

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -18,9 +18,9 @@ describe('`updateQuality`', () => {
   });
 
   it('Updates the quality of sulfuras', () => {
-    const sulfuras = new Item('Sulfuras, Hand of Ragnaros', 0, 50);
+    const sulfuras = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
     updateQuality([sulfuras]);
-    expect(sulfuras.quality).toBe(50);
+    expect(sulfuras.quality).toBe(80);
   })
 
   it('Updates the quality of backstage passes', () => {

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -16,4 +16,10 @@ describe('`updateQuality`', () => {
     expect(brieExpired.quality).toBe(12);
     expect(brieHighestQuality.quality).toBe(50);
   });
+
+  it('Updates the quality of sulfuras', () => {
+    const sulfuras = new Item('Sulfuras, Hand of Ragnaros', 0, 50);
+    updateQuality([sulfuras]);
+    expect(sulfuras.quality).toBe(50);
+  })
 });

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -8,8 +8,12 @@ describe('`updateQuality`', () => {
   });
 
   it('Updates the quality of aged brie', () => {
-    const testItem = new Item('Aged Brie', 7, 2);
-    updateQuality([testItem])
-    expect(testItem.quality).toBe(3);
+    const brie = new Item('Aged Brie', 7, 2);
+    const brieExpired = new Item('Aged Brie', -1, 10)
+    const brieHighestQuality = new Item('Aged Brie', -1, 50)
+    updateQuality([brie, brieExpired, brieHighestQuality])
+    expect(brie.quality).toBe(3);
+    expect(brieExpired.quality).toBe(12);
+    expect(brieHighestQuality.quality).toBe(50);
   });
 });

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -1,11 +1,15 @@
 import { Item, updateQuality } from './gilded_rose';
 
 describe('`updateQuality`', () => {
-  it.todo("Why won't my test pass?", () => {
+  it("Why won't my test pass?", () => {
     const standardItem = new Item('Haunted Shoe', 10, 10);
     updateQuality([standardItem]);
-    expect(standardItem.sell_in).toBe(4);
+    expect(standardItem.sell_in).toBe(9);
   });
 
-  it.todo('This is a good place for a good test!');
+  it('Updates the quality of aged brie', () => {
+    const testItem = new Item('Aged Brie', 7, 2);
+    updateQuality([testItem])
+    expect(testItem.quality).toBe(3);
+  });
 });

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -55,7 +55,7 @@ describe('`updateQuality`', () => {
     expect(minimumQualityElixir.quality).toBe(0)
   })
 
-  it('Updates the quality of conjured items', () => {
+  it.skip('Updates the quality of conjured items', () => {
     const cake = new Item('Conjured Mana Cake', 5, 10)
     const oldCake = new Item('Conjured Mana Cake', -1, 10)
     updateQuality([cake, oldCake])

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -54,4 +54,12 @@ describe('`updateQuality`', () => {
     expect(oldElixir.quality).toBe(26)
     expect(minimumQualityElixir.quality).toBe(0)
   })
+
+  it('Updates the quality of conjured items', () => {
+    const cake = new Item('Conjured Mana Cake', 5, 10)
+    const oldCake = new Item('Conjured Mana Cake', -1, 10)
+    updateQuality([cake, oldCake])
+    expect(cake.quality).toBe(8)
+    expect(oldCake.quality).toBe(6)
+  })
 });


### PR DESCRIPTION
## Description
Disabled the test for conjured items until the source code for conjured items has been added.

## Spec

See Issue: [ISSUE_NUMBER](https://sparkbox.atlassian.net/browse/FSA2021-28)

## Validation

- [ ] This PR has code changes, and our linters still pass.
- [✔️ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Run npm test
