### PR TITLE
Test: Add test for conjured items

### DIFF
--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -105,7 +105,22 @@ describe('updating of sulfuras', () => {
 });
 
 describe('updating of conjured items', () => {
-  it.todo('decreases the sell_in of conjured items by 1');
+  const cake = new Item('Conjured Mana Cake', 5, 10);
+  const oldCake = new Item('Conjured Mana Cake', -1, 10);
 
-  it.todo('decreases the quality of of conjured items by 2');
+  beforeAll(() => {
+    updateQuality([cake, oldCake]);
+  });
+
+  it.skip('decreases the sell_in of conjured items by 1', () => {
+    expect(cake.sell_in).toBe(4);
+  });
+
+  it.skip('decreases the quality of conjured items by 2', () => {
+    expect(cake.quality).toBe(8);
+  });
+
+  it.skip('decreases the quality of conjured items by 4', () => {
+    expect(oldCake.quality).toBe(6);
+  });
 });


### PR DESCRIPTION
## Description
Added three tests in the describe block for conjured items.
Currently, conjured items are not covered in the source code, so these tests are all skipped.

## Spec

See Issue: [FSA2021-31](https://sparkbox.atlassian.net/browse/FSA2021-31)

## Validation

- [✔️ ] This PR has code changes, and our linters still pass.
- [✔️ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to `test--add-conjured-items-test` and run `npm test` and `npm run lint`
