### PR TITLE
refactor: move sulfuras logic

### DIFF
--- a/src/gilded_rose.js
+++ b/src/gilded_rose.js
@@ -23,11 +23,12 @@ updateQuality(items);
 */
 export function updateQuality(items) {
   for (var i = 0; i < items.length; i++) {
+    if (items[i].name === 'Sulfuras, Hand of Ragnaros') {
+      break;
+    }
     if (items[i].name != 'Aged Brie' && items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
       if (items[i].quality > 0) {
-        if (items[i].name != 'Sulfuras, Hand of Ragnaros') {
-          items[i].quality = items[i].quality - 1
-        }
+        items[i].quality = items[i].quality - 1
       }
     } else {
       if (items[i].quality < 50) {
@@ -46,16 +47,14 @@ export function updateQuality(items) {
         }
       }
     }
-    if (items[i].name != 'Sulfuras, Hand of Ragnaros') {
-      items[i].sell_in = items[i].sell_in - 1;
-    }
+
+    items[i].sell_in = items[i].sell_in - 1;
+
     if (items[i].sell_in < 0) {
       if (items[i].name != 'Aged Brie') {
         if (items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
           if (items[i].quality > 0) {
-            if (items[i].name != 'Sulfuras, Hand of Ragnaros') {
               items[i].quality = items[i].quality - 1
-            }
           }
         } else {
           items[i].quality = items[i].quality - items[i].quality


### PR DESCRIPTION
## Description
Since there are several nested if statements specifying action to take if item name is NOT Sulfuras, this simplifies the code by removing all statements stating `if (items[i].name != 'Sulfuras, Hand of Ragnaros')` and instead creating a case for `if (items[i].name === 'Sulfuras...')` at the top. Used `break` because Sulfuras items do not change in sell_in or quality, though perhaps this could be changed later.

Note that none of the statements under each `if (items[i].name != 'Sulfuras, Hand of Ragnaros')` were removed, just the if statements themselves.

## Spec

See Issue: [33](https://sparkbox.atlassian.net/browse/FSA2021-33)

## Validation

- [X] This PR has code changes, and our linters still pass.
- [X] This PR has code changes, and our tests still pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to `refactor--move-sulfuras-logic`
2. Determine that all tests still pass.
