### PR TITLE
Refactor - consolidate mutation

### DIFF
--- a/src/gilded_rose.js
+++ b/src/gilded_rose.js
@@ -21,48 +21,57 @@ const items = [
 
 updateQuality(items);
 */
+
+function mutateItemQuality(currentQuality, amount = 1) {
+  /**
+   * checks if adding the two values would cancel them out and returns 0 before adding
+   * this sets the quality of backstage passes to 0 without needing to check if quality is 50+
+   * otherwise ('Backstage passes to a TAFKAL80ETC concert', -1, 50) is not handled properly
+   */
+  if (-(currentQuality) === amount) {
+    return 0;
+  }
+    // does not allow quality to be increased over 50
+  if (currentQuality >= 50) {
+    return currentQuality;
+  }
+  // quality can increase or decrease, if no amount is specified quality will increase by 1
+  return currentQuality + amount;
+}
+
+function mutateItemSellIn(currentSellIn, amount = 1) {
+  // is generally always decremented (by 1)
+  return currentSellIn - amount;
+}
+
 export function updateQuality(items) {
   for (var i = 0; i < items.length; i++) {
     if (items[i].name === 'Sulfuras, Hand of Ragnaros') {
       break;
     } else if (items[i].name === 'Aged Brie') {
-      if (items[i].quality < 50) {
-        items[i].quality = items[i].quality + 1
+        items[i].quality = mutateItemQuality(items[i].quality);
         if (items[i].sell_in < 0) {
-          items[i].quality = items[i].quality + 1
-        }
+          items[i].quality = mutateItemQuality(items[i].quality);
       }
     } else if (items[i].name === 'Backstage passes to a TAFKAL80ETC concert') {
-      if (items[i].quality < 50) {
-        items[i].quality = items[i].quality + 1
+        items[i].quality = mutateItemQuality(items[i].quality);
         if (items[i].sell_in < 11) {
-          items[i].quality = items[i].quality + 1
+        items[i].quality = mutateItemQuality(items[i].quality);
         }
         if (items[i].sell_in < 6) {
-          items[i].quality = items[i].quality + 1
+          items[i].quality = mutateItemQuality(items[i].quality);
         }
-      }
       if (items[i].sell_in <= 0) {
-        items[i].quality = items[i].quality - items[i].quality
+        items[i].quality = mutateItemQuality(items[i].quality, -(items[i].quality));
+
+      }
+    } else {
+      items[i].quality = mutateItemQuality(items[i].quality, -1);
+      if (items[i].sell_in <= 0) {
+        items[i].quality = mutateItemQuality(items[i].quality, -1);
       }
     }
-
-    if (items[i].name != 'Aged Brie'
-    && items[i].name != 'Backstage passes to a TAFKAL80ETC concert'
-    && items[i].quality > 0) {
-      // handles updating of general items
-      items[i].quality = items[i].quality - 1
-    } 
-    // handles sell in for all items except sulfuras
-    items[i].sell_in = items[i].sell_in - 1;
-
-    if (items[i].sell_in < 0) {
-      if (items[i].name != 'Aged Brie') {
-        if (items[i].name != 'Backstage passes to a TAFKAL80ETC concert'
-        && items[i].quality > 0) {
-              items[i].quality = items[i].quality - 1
-        } 
-      } 
-    }
+    // handles decrementing of sell in for all items except sulfuras
+    items[i].sell_in = mutateItemSellIn(items[i].sell_in);
   }
 }

--- a/src/gilded_rose.js
+++ b/src/gilded_rose.js
@@ -23,17 +23,18 @@ updateQuality(items);
 */
 
 function mutateItemQuality(currentQuality, amount = 1) {
-  /**
-   * checks if adding the two values would cancel them out and returns 0 before adding
-   * this sets the quality of backstage passes to 0 without needing to check if quality is 50+
-   * otherwise ('Backstage passes to a TAFKAL80ETC concert', -1, 50) is not handled properly
-   */
-  if (-(currentQuality) === amount) {
-    return 0;
-  }
-    // does not allow quality to be increased over 50
   if (currentQuality >= 50) {
-    return currentQuality;
+    // the rules state that the quality should never be more than 50
+    if (currentQuality + amount === 0) {
+      /**
+       * The only time we will change the quality when it's 50 or more is when 
+       * we want to change backstage passes' quality to 0 (if sellin is less than 0).
+       * example: new Item('Backstage passes to a TAFKAL80ETC concert', -1, 50)
+       */
+      return 0;
+    } else {
+      return currentQuality;
+    }
   }
   // quality can increase or decrease, if no amount is specified quality will increase by 1
   return currentQuality + amount;
@@ -49,26 +50,26 @@ export function updateQuality(items) {
     if (items[i].name === 'Sulfuras, Hand of Ragnaros') {
       break;
     } else if (items[i].name === 'Aged Brie') {
-        items[i].quality = mutateItemQuality(items[i].quality);
         if (items[i].sell_in < 0) {
+          items[i].quality = mutateItemQuality(items[i].quality, 2);
+        } else {
           items[i].quality = mutateItemQuality(items[i].quality);
-      }
+        }
     } else if (items[i].name === 'Backstage passes to a TAFKAL80ETC concert') {
-        items[i].quality = mutateItemQuality(items[i].quality);
-        if (items[i].sell_in < 11) {
-        items[i].quality = mutateItemQuality(items[i].quality);
-        }
-        if (items[i].sell_in < 6) {
-          items[i].quality = mutateItemQuality(items[i].quality);
-        }
       if (items[i].sell_in <= 0) {
         items[i].quality = mutateItemQuality(items[i].quality, -(items[i].quality));
-
+      } else if (items[i].sell_in < 6) {
+        items[i].quality = mutateItemQuality(items[i].quality, 3);
+      } else if (items[i].sell_in < 11) {
+        items[i].quality = mutateItemQuality(items[i].quality, 2);
+      } else {
+        items[i].quality = mutateItemQuality(items[i].quality);
       }
     } else {
-      items[i].quality = mutateItemQuality(items[i].quality, -1);
       if (items[i].sell_in <= 0) {
-        items[i].quality = mutateItemQuality(items[i].quality, -1);
+        items[i].quality = mutateItemQuality(items[i].quality, -2)
+      } else {
+        items[i].quality = mutateItemQuality(items[i].quality, -1)
       }
     }
     // handles decrementing of sell in for all items except sulfuras

--- a/src/gilded_rose.js
+++ b/src/gilded_rose.js
@@ -25,26 +25,35 @@ export function updateQuality(items) {
   for (var i = 0; i < items.length; i++) {
     if (items[i].name === 'Sulfuras, Hand of Ragnaros') {
       break;
-    }
-    if (items[i].name != 'Aged Brie'
-    && items[i].name != 'Backstage passes to a TAFKAL80ETC concert'
-    && items[i].quality > 0) {
-      items[i].quality = items[i].quality - 1
-    } else {
+    } else if (items[i].name === 'Aged Brie') {
       if (items[i].quality < 50) {
         items[i].quality = items[i].quality + 1
-        if (items[i].name == 'Backstage passes to a TAFKAL80ETC concert'
-        && items[i].sell_in < 11
-        && items[i].quality < 50) {
+        if (items[i].sell_in < 0) {
           items[i].quality = items[i].quality + 1
-          if (items[i].sell_in < 6
-            && items[i].quality < 50) {
-            items[i].quality = items[i].quality + 1
-          }
         }
+      }
+    } else if (items[i].name === 'Backstage passes to a TAFKAL80ETC concert') {
+      if (items[i].quality < 50) {
+        items[i].quality = items[i].quality + 1
+        if (items[i].sell_in < 11) {
+          items[i].quality = items[i].quality + 1
+        }
+        if (items[i].sell_in < 6) {
+          items[i].quality = items[i].quality + 1
+        }
+      }
+      if (items[i].sell_in <= 0) {
+        items[i].quality = items[i].quality - items[i].quality
       }
     }
 
+    if (items[i].name != 'Aged Brie'
+    && items[i].name != 'Backstage passes to a TAFKAL80ETC concert'
+    && items[i].quality > 0) {
+      // handles updating of general items
+      items[i].quality = items[i].quality - 1
+    } 
+    // handles sell in for all items except sulfuras
     items[i].sell_in = items[i].sell_in - 1;
 
     if (items[i].sell_in < 0) {
@@ -52,14 +61,8 @@ export function updateQuality(items) {
         if (items[i].name != 'Backstage passes to a TAFKAL80ETC concert'
         && items[i].quality > 0) {
               items[i].quality = items[i].quality - 1
-        } else {
-          items[i].quality = items[i].quality - items[i].quality
-        }
-      } else {
-        if (items[i].quality < 50) {
-          items[i].quality = items[i].quality + 1
-        }
-      }
+        } 
+      } 
     }
   }
 }


### PR DESCRIPTION
## Description

Do we still have if statements nested within if statements? Yes... and this logic could arguably be neatened up in a future refactoring.

This refactoring first moves each type of item (backstage passes, aged brie, sulfuras, normal items) into their own block. Then it reduces the number of mutations to items. For instance, with backstage passes, instead of incrementing quality once, then again if there are 10 sell in days or less, then again if there are 5 sell in days or less, logic has been updated so that the quality is only modified once for each item.

This (I hope?) makes it smoother and less redundant when it comes to creating a fresh set of data rather than mutating the data later on.

## Spec

Hopefully might be helpful to Flash in completing: [37](https://sparkbox.atlassian.net/browse/FSA2021-37)

## Validation

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has refactored code, and tests still pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Check linting and testing to verify they still work.
