### PR TITLE
Feat  print items in ordered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ If you want to get cracking on the JavaScript source then do this:
 
     git clone git@github.com:guyroyse/gilded-rose-javascript.git
 
+To start the Express server, run `npm start` and navigate to:
+
+    http://localhost:3000
+
 Hi and welcome to team Gilded Rose.
 
 As you know, we are a small inn with a prime location in a prominent city ran

--- a/server.js
+++ b/server.js
@@ -1,11 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import express from 'express';
+import { htmlListItems } from './src/item_list';
 
 const app = express();
 const PORT = 3000;
 
 app.get('/', (req, res) => {
-  res.send('Hello World!');
+  res.send(htmlListItems);
 });
 
 app.listen(PORT, () => {

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -1,4 +1,5 @@
 import { Item, updateQuality } from './gilded_rose';
+import getHtmlListFromArray from './item_list';
 
 describe('updating of standard items', () => {
   it('decreases the sell_in of a standard item by 1', () => {
@@ -122,5 +123,29 @@ describe('updating of conjured items', () => {
 
   it.skip('decreases the quality of conjured items by 4', () => {
     expect(oldCake.quality).toBe(6);
+  });
+});
+
+describe('generating ordered lists of items', () => {
+  it('generates an ordered list with one list item', () => {
+    const list = ['Testing'];
+    const testOutput = getHtmlListFromArray(list);
+    expect(testOutput).toBe(`<ol><li>${JSON.stringify('Testing')}</li></ol>`);
+  });
+  it('generates an ordered list with multiple list items', () => {
+    const list = ['Test 1', 'Test 2', 'Test 3'];
+    const testOutput = getHtmlListFromArray(list);
+    expect(testOutput).toBe(`<ol><li>${JSON.stringify('Test 1')}</li><li>${JSON.stringify('Test 2')}</li><li>${JSON.stringify('Test 3')}</li></ol>`);
+  });
+  it('generates an empty ol tag', () => {
+    const emptyList = [];
+    const testOutput = getHtmlListFromArray(emptyList);
+    expect(testOutput).toBe('<ol></ol>');
+  });
+  it('generates an ordered list with an item from the gilded rose', () => {
+    const sulfuras = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
+    const list = [sulfuras];
+    const testOutput = getHtmlListFromArray(list);
+    expect(testOutput).toBe(`<ol><li>${JSON.stringify(sulfuras)}</li></ol>`);
   });
 });

--- a/src/item_list.js
+++ b/src/item_list.js
@@ -1,0 +1,21 @@
+import { Item } from './gilded_rose';
+
+const items = [
+  new Item('+5 Dexterity Vest', 10, 20),
+  new Item('Aged Brie', 2, 0),
+  new Item('Elixir of the Mongoose', 5, 7),
+  new Item('Sulfuras, Hand of Ragnaros', 0, 80),
+  new Item('Backstage passes to a TAFKAL80ETC concert', 15, 20),
+  new Item('Conjured Mana Cake', 3, 6),
+];
+
+export default function getHtmlListFromArray(itemArray) {
+  let htmlOutput = '<ol>';
+  itemArray.forEach((item) => {
+    htmlOutput += `<li>${JSON.stringify(item)}</li>`;
+  });
+  htmlOutput += '</ol>';
+  return htmlOutput;
+}
+
+export const htmlListItems = getHtmlListFromArray(items);


### PR DESCRIPTION
## Description

Created a new function that took an array as an argument and returned it formatted as an HTML ordered list.
I then passed an array of items from the gilded rose to this function, stored the ordered list it returned as a variable,
and then displayed this variable on the Express server.

## Spec

See Issue: [FSA2021-38](https://sparkbox.atlassian.net/browse/FSA2021-38)

## Validation
<!-- delete anything irrelevant to this PR -->

- [✅ ] This PR has code changes, and our linters still pass.
- [✅ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to `feat--print-items-in-ordered-list` and run `npm test` and `npm run lint`.
