### PR TITLE
Feat  conjured items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3009,6 +3009,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -62,7 +62,7 @@ export function updateItems(items) {
   for (var i = 0; i < items.length; i++) {
     items[i].sell_in = calcNextSellIn(items[i]);
 
-    const calcNextQuality = qualityStrategies[item.name] || qualityStrategies["default"];
-    items[i].quality = calcNextQuality(items[i]);
+    const calcQuality = qualityStrategies[items[i].name] || qualityStrategies["default"];
+    items[i].quality = calcQuality(items[i]);
   }
 }

--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -22,47 +22,60 @@ const items = [
 updateQuality(items);
 */
 
-const qualityStrategies = {
-  "Aged Brie": item => Math.min(50, calcNextQuality(item, 1)),
-  "Backstage passes to a TAFKAL80ETC concert": item => Math.min(50,getTicketQuality(item)),
-  "Sulfuras, Hand of Ragnaros": item => item.quality,
-  "default": item => Math.max(0, calcNextQuality(item, -1))
+//Quality Strategies & strategies object
+const updateStrategies = {
+  "Aged Brie": cheeseUpdate,
+  "Backstage passes to a TAFKAL80ETC concert": ticketUpdate,
+  "Sulfuras, Hand of Ragnaros": legendaryUpdate,
+  "default": defaultUpdate
+};
+
+function cheeseUpdate(item) {
+  let change = (item.sell_in < 0 ? 2 : 1);
+  return clampQuality(item.quality + change);
 }
 
-function calcNextSellIn(item) {
+function legendaryUpdate(item) {
+  return item.quality;
+}
+
+function ticketUpdate(item) {
+  let change = 0;
+  if(item.sell_in <= 10 && item.sell_in >=0) {
+    change = 2
+  }
+  else if(item.sell_in > 10) {
+    change = 1;
+  }
+  else {
+    change = -50;
+  }
+  return clampQuality(item.quality + change);
+}
+
+function defaultUpdate(item) {
+  let change = (item.sell_in < 0 ? -2 : -1);
+  return clampQuality(item.quality + change);
+}
+
+//Sell-in updates
+function updateSellIn(item) {
   if(item.name != "Sulfuras, Hand of Ragnaros"){
     return item.sell_in - 1;
   }
   return item.sell_in;
 }
 
-//Most items follow this logic, with just changed values.
-function calcNextQuality(item, change) {
-  if(item.sell_in >= 0) {
-    return item.quality + change;
-  }
-  else {
-    return item.quality + change * 2;
-  }
+//Helpers
+function clampQuality(quality) {
+  return Math.max(0,Math.min(50,quality));
 }
 
-//Tickets have enough conditionals to merit a named function.
-//Normally I'd use subclasses/polymorphism for this, but...goblins.
-function getTicketQuality(item) {
-  if(item.sell_in <= 10 && item.sell_in >=0) {
-    return item.quality + 2;
-  }
-  if(item.sell_in > 10) {
-    return item.quality + 1;
-  }
-  return 0;
-}
-
+//Select sell-in, quality strategies
 export function updateItems(items) {
-  for (var i = 0; i < items.length; i++) {
-    items[i].sell_in = calcNextSellIn(items[i]);
-
-    const calcQuality = qualityStrategies[items[i].name] || qualityStrategies["default"];
-    items[i].quality = calcQuality(items[i]);
-  }
+  items.map((item) => {
+    item.sell_in = updateSellIn(item);
+    let updateQuality = updateStrategies[item.name] || updateStrategies["default"];
+    item.quality = updateQuality(item);
+  });
 }

--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -21,50 +21,48 @@ const items = [
 
 updateQuality(items);
 */
-export function updateQuality(items) {
+
+const qualityStrategies = {
+  "Aged Brie": item => Math.min(50, calcNextQuality(item, 1)),
+  "Backstage passes to a TAFKAL80ETC concert": item => Math.min(50,getTicketQuality(item)),
+  "Sulfuras, Hand of Ragnaros": item => item.quality,
+  "default": item => Math.max(0, calcNextQuality(item, -1))
+}
+
+function calcNextSellIn(item) {
+  if(item.name != "Sulfuras, Hand of Ragnaros"){
+    return item.sell_in - 1;
+  }
+  return item.sell_in;
+}
+
+//Most items follow this logic, with just changed values.
+function calcNextQuality(item, change) {
+  if(item.sell_in >= 0) {
+    return item.quality + change;
+  }
+  else {
+    return item.quality + change * 2;
+  }
+}
+
+//Tickets have enough conditionals to merit a named function.
+//Normally I'd use subclasses/polymorphism for this, but...goblins.
+function getTicketQuality(item) {
+  if(item.sell_in <= 10 && item.sell_in >=0) {
+    return item.quality + 2;
+  }
+  if(item.sell_in > 10) {
+    return item.quality + 1;
+  }
+  return 0;
+}
+
+export function updateItems(items) {
   for (var i = 0; i < items.length; i++) {
-    if (items[i].name != 'Aged Brie' && items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-      if (items[i].quality > 0) {
-        if (items[i].name != 'Sulfuras, Hand of Ragnaros') {
-          items[i].quality = items[i].quality - 1
-        }
-      }
-    } else {
-      if (items[i].quality < 50) {
-        items[i].quality = items[i].quality + 1
-        if (items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
-          if (items[i].sell_in < 11) {
-            if (items[i].quality < 50) {
-              items[i].quality = items[i].quality + 1
-            }
-          }
-          if (items[i].sell_in < 6) {
-            if (items[i].quality < 50) {
-              items[i].quality = items[i].quality + 1
-            }
-          }
-        }
-      }
-    }
-    if (items[i].name != 'Sulfuras, Hand of Ragnaros') {
-      items[i].sell_in = items[i].sell_in - 1;
-    }
-    if (items[i].sell_in < 0) {
-      if (items[i].name != 'Aged Brie') {
-        if (items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-          if (items[i].quality > 0) {
-            if (items[i].name != 'Sulfuras, Hand of Ragnaros') {
-              items[i].quality = items[i].quality - 1
-            }
-          }
-        } else {
-          items[i].quality = items[i].quality - items[i].quality
-        }
-      } else {
-        if (items[i].quality < 50) {
-          items[i].quality = items[i].quality + 1
-        }
-      }
-    }
+    items[i].sell_in = calcNextSellIn(items[i]);
+
+    const calcNextQuality = qualityStrategies[item.name] || qualityStrategies["default"];
+    items[i].quality = calcNextQuality(items[i]);
   }
 }

--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -27,6 +27,7 @@ const updateStrategies = {
   "Aged Brie": cheeseUpdate,
   "Backstage passes to a TAFKAL80ETC concert": ticketUpdate,
   "Sulfuras, Hand of Ragnaros": legendaryUpdate,
+  "Conjured Mana Cake": conjuredUpdate,
   "default": defaultUpdate
 };
 
@@ -50,6 +51,11 @@ function ticketUpdate(item) {
   else {
     change = -50;
   }
+  return clampQuality(item.quality + change);
+}
+
+function conjuredUpdate(item){
+  let change = (item.sell_in < 0 ? -4 : -2);
   return clampQuality(item.quality + change);
 }
 

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -80,7 +80,7 @@ describe('`updateItems`', () => {
     expect(ticketItem.quality).toBe(0);
   });
 
-  it('does not change quality after sell-in drops below 0', () => {
+  it('does not change the quality of tickets after sell-in drops below 0', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
     updateItems([ticketItem]);
     updateItems([ticketItem]);
@@ -88,19 +88,19 @@ describe('`updateItems`', () => {
   });
 
   // The Conjured Mana Cake decreases in quality twice as fast as other items
-  it('decreases in quality by 2 when sell_in >= 0', () => {
+  it('decreases conjured item quality by 2 when sell_in >= 0', () => {
     const conjuredItem = new Item('Conjured Mana Cake', 10, 10);
     updateItems([conjuredItem]);
     expect(conjuredItem.quality).toBe(8);
   });
 
-  it('decreases in quality by 4 when sell_in < 0', () => {
+  it('decreases the quality of a conjured item"s quality by 4 when sell_in < 0', () => {
     const conjuredItem = new Item('Conjured Mana Cake', 0, 10);
     updateItems([conjuredItem]);
     expect(conjuredItem.quality).toBe(6);
   });
 
-  it('cannot have a quality below 0', () => {
+  it('cannot decrement the quality of a conjured item below 0', () => {
     const conjuredItem = new Item('Conjured Mana Cake', 0, 0);
     updateItems([conjuredItem]);
     expect(conjuredItem.quality).toBe(0);

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -1,28 +1,28 @@
-import { Item, updateQuality } from './gilded_rose';
+import { Item, updateItems } from './gilded_rose';
 
-describe('`updateQuality`', () => {
+describe('`updateItems`', () => {
   //'Haunted Shoe' is a generic item and represents default behavior.
   it('deprecates the sell in by one for a Haunted Shoe', () => {
     const standardItem = new Item('Haunted Shoe', 10, 10);
-    updateQuality([standardItem]);
+    updateItems([standardItem]);
     expect(standardItem.sell_in).toBe(9);
   });
 
   it('deprecates the quality by one for a Haunted Shoe while sell in is >=0', () => {
     const standardItem = new Item('Haunted Shoe', 10, 10);
-    updateQuality([standardItem]);
+    updateItems([standardItem]);
     expect(standardItem.quality).toBe(9);
   });
 
   it('deprecates the quality by 2 for a Haunted Shoe while sell in is <0', () => {
     const standardItem = new Item('Haunted Shoe', 0, 10);
-    updateQuality([standardItem]);
+    updateItems([standardItem]);
     expect(standardItem.quality).toBe(8);
   });
 
   it('does not lower quality of a Haunted Shoe below 0', () => {
     const standardItem = new Item('Haunted Shoe', 10, 0);
-    updateQuality([standardItem]);
+    updateItems([standardItem]);
     expect(standardItem.quality).toBe(0);
   });
 
@@ -30,13 +30,13 @@ describe('`updateQuality`', () => {
   //I am unsure if they are also supposed to have quality >50, as shown here.
   it('does not lower the quality of a Hand of Ragnaros', () => {
     const legendaryItem = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
-    updateQuality([legendaryItem]);
+    updateItems([legendaryItem]);
     expect(legendaryItem.quality).toBe(80);
   })
 
   it('does not lower the sell_in of a Hand of Ragnaros', () => {
     const legendaryItem = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
-    updateQuality([legendaryItem]);
+    updateItems([legendaryItem]);
     expect(legendaryItem.sell_in).toBe(0);
   })
 
@@ -44,19 +44,19 @@ describe('`updateQuality`', () => {
   //should cap at 50 quality.
   it('increments the quality of aged brie by 1 as sell-in decreases', () => {
     const cheeseItem = new Item('Aged Brie', 10, 10);
-    updateQuality([cheeseItem]);
+    updateItems([cheeseItem]);
     expect(cheeseItem.quality).toBe(11);
   })
 
   it('increments the quality of aged brie by 2 when sell-in <0', () => {
     const cheeseItem = new Item('Aged Brie', 0, 10);
-    updateQuality([cheeseItem]);
+    updateItems([cheeseItem]);
     expect(cheeseItem.quality).toBe(12);
   })
 
   it('cannot increment the quality of aged brie once it is 50', () => {
     const cheeseItem = new Item('Aged Brie', 50, 50);
-    updateQuality([cheeseItem]);
+    updateItems([cheeseItem]);
     expect(cheeseItem.quality).toBe(50);
   })
 
@@ -64,26 +64,26 @@ describe('`updateQuality`', () => {
   //at 0 once sell-in <=0. They are otherwise identical to aged brie.
   it('increments the quality of tickets by 1 while sell-in >10', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 15, 10);
-    updateQuality([ticketItem]);
+    updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(11);
   })
 
   it('increments the quality of tickets by 2 while sell-in <=10', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 10, 10);
-    updateQuality([ticketItem]);
+    updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(12);
   })
 
   it('sets the quality of tickets to 0 when sell-in is 0', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
-    updateQuality([ticketItem]);
+    updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(0);
   })
 
   it('does not change quality after sell-in drops below 0', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
-    updateQuality([ticketItem]);
-    updateQuality([ticketItem]);
+    updateItems([ticketItem]);
+    updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(0);
   })
 });

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -1,7 +1,7 @@
 import { Item, updateItems } from './gilded_rose';
 
 describe('`updateItems`', () => {
-  //'Haunted Shoe' is a generic item and represents default behavior.
+  // 'Haunted Shoe' is a generic item and represents default behavior.
   it('deprecates the sell in by one for a Haunted Shoe', () => {
     const standardItem = new Item('Haunted Shoe', 10, 10);
     updateItems([standardItem]);
@@ -26,64 +26,64 @@ describe('`updateItems`', () => {
     expect(standardItem.quality).toBe(0);
   });
 
-  //Legendary items do not have sell by dates or decrease in quality.
-  //I am unsure if they are also supposed to have quality >50, as shown here.
+  // Legendary items do not have sell by dates or decrease in quality.
+  // I am unsure if they are also supposed to have quality >50, as shown here.
   it('does not lower the quality of a Hand of Ragnaros', () => {
     const legendaryItem = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
     updateItems([legendaryItem]);
     expect(legendaryItem.quality).toBe(80);
-  })
+  });
 
   it('does not lower the sell_in of a Hand of Ragnaros', () => {
     const legendaryItem = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
     updateItems([legendaryItem]);
     expect(legendaryItem.sell_in).toBe(0);
-  })
+  });
 
-  //Aged Brie is meant to increase in quality as sell by decreases. It 
-  //should cap at 50 quality.
+  // Aged Brie is meant to increase in quality as sell by decreases. It
+  // should cap at 50 quality.
   it('increments the quality of aged brie by 1 as sell-in decreases', () => {
     const cheeseItem = new Item('Aged Brie', 10, 10);
     updateItems([cheeseItem]);
     expect(cheeseItem.quality).toBe(11);
-  })
+  });
 
   it('increments the quality of aged brie by 2 when sell-in <0', () => {
     const cheeseItem = new Item('Aged Brie', 0, 10);
     updateItems([cheeseItem]);
     expect(cheeseItem.quality).toBe(12);
-  })
+  });
 
   it('cannot increment the quality of aged brie once it is 50', () => {
     const cheeseItem = new Item('Aged Brie', 50, 50);
     updateItems([cheeseItem]);
     expect(cheeseItem.quality).toBe(50);
-  })
+  });
 
-  //Tickets go up by 2 quality once sell-in <=10, but their quality is locked 
-  //at 0 once sell-in <=0. They are otherwise identical to aged brie.
+  // Tickets go up by 2 quality once sell-in <=10, but their quality is locked
+  // at 0 once sell-in <=0. They are otherwise identical to aged brie.
   it('increments the quality of tickets by 1 while sell-in >10', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 15, 10);
     updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(11);
-  })
+  });
 
   it('increments the quality of tickets by 2 while sell-in <=10', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 10, 10);
     updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(12);
-  })
+  });
 
   it('sets the quality of tickets to 0 when sell-in is 0', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
     updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(0);
-  })
+  });
 
   it('does not change quality after sell-in drops below 0', () => {
     const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
     updateItems([ticketItem]);
     updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(0);
-  })
+  });
 });

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -86,4 +86,23 @@ describe('`updateItems`', () => {
     updateItems([ticketItem]);
     expect(ticketItem.quality).toBe(0);
   });
+
+  // The Conjured Mana Cake decreases in quality twice as fast as other items
+  it('decreases in quality by 2 when sell_in >= 0', () => {
+    const conjuredItem = new Item('Conjured Mana Cake', 10, 10);
+    updateItems([conjuredItem]);
+    expect(conjuredItem.quality).toBe(8);
+  });
+
+  it('decreases in quality by 4 when sell_in < 0', () => {
+    const conjuredItem = new Item('Conjured Mana Cake', 0, 10);
+    updateItems([conjuredItem]);
+    expect(conjuredItem.quality).toBe(6);
+  });
+
+  it('cannot have a quality below 0', () => {
+    const conjuredItem = new Item('Conjured Mana Cake', 0, 0);
+    updateItems([conjuredItem]);
+    expect(conjuredItem.quality).toBe(0);
+  });
 });

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -1,11 +1,89 @@
 import { Item, updateQuality } from './gilded_rose';
 
 describe('`updateQuality`', () => {
+  //'Haunted Shoe' is a generic item and represents default behavior.
   it('deprecates the sell in by one for a Haunted Shoe', () => {
     const standardItem = new Item('Haunted Shoe', 10, 10);
     updateQuality([standardItem]);
     expect(standardItem.sell_in).toBe(9);
   });
 
-  it.todo('This is a good place for a good test!');
+  it('deprecates the quality by one for a Haunted Shoe while sell in is >=0', () => {
+    const standardItem = new Item('Haunted Shoe', 10, 10);
+    updateQuality([standardItem]);
+    expect(standardItem.quality).toBe(9);
+  });
+
+  it('deprecates the quality by 2 for a Haunted Shoe while sell in is <0', () => {
+    const standardItem = new Item('Haunted Shoe', 0, 10);
+    updateQuality([standardItem]);
+    expect(standardItem.quality).toBe(8);
+  });
+
+  it('does not lower quality of a Haunted Shoe below 0', () => {
+    const standardItem = new Item('Haunted Shoe', 10, 0);
+    updateQuality([standardItem]);
+    expect(standardItem.quality).toBe(0);
+  });
+
+  //Legendary items do not have sell by dates or decrease in quality.
+  //I am unsure if they are also supposed to have quality >50, as shown here.
+  it('does not lower the quality of a Hand of Ragnaros', () => {
+    const legendaryItem = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
+    updateQuality([legendaryItem]);
+    expect(legendaryItem.quality).toBe(80);
+  })
+
+  it('does not lower the sell_in of a Hand of Ragnaros', () => {
+    const legendaryItem = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
+    updateQuality([legendaryItem]);
+    expect(legendaryItem.sell_in).toBe(0);
+  })
+
+  //Aged Brie is meant to increase in quality as sell by decreases. It 
+  //should cap at 50 quality.
+  it('increments the quality of aged brie by 1 as sell-in decreases', () => {
+    const cheeseItem = new Item('Aged Brie', 10, 10);
+    updateQuality([cheeseItem]);
+    expect(cheeseItem.quality).toBe(11);
+  })
+
+  it('increments the quality of aged brie by 2 when sell-in <0', () => {
+    const cheeseItem = new Item('Aged Brie', 0, 10);
+    updateQuality([cheeseItem]);
+    expect(cheeseItem.quality).toBe(12);
+  })
+
+  it('cannot increment the quality of aged brie once it is 50', () => {
+    const cheeseItem = new Item('Aged Brie', 50, 50);
+    updateQuality([cheeseItem]);
+    expect(cheeseItem.quality).toBe(50);
+  })
+
+  //Tickets go up by 2 quality once sell-in <=10, but their quality is locked 
+  //at 0 once sell-in <=0. They are otherwise identical to aged brie.
+  it('increments the quality of tickets by 1 while sell-in >10', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 15, 10);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(11);
+  })
+
+  it('increments the quality of tickets by 2 while sell-in <=10', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 10, 10);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(12);
+  })
+
+  it('sets the quality of tickets to 0 when sell-in is 0', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(0);
+  })
+
+  it('does not change quality after sell-in drops below 0', () => {
+    const ticketItem = new Item('Backstage passes to a TAFKAL80ETC concert', 0, 10);
+    updateQuality([ticketItem]);
+    updateQuality([ticketItem]);
+    expect(ticketItem.quality).toBe(0);
+  })
 });

--- a/src/js/homepage_items.js
+++ b/src/js/homepage_items.js
@@ -1,4 +1,4 @@
-import { Item, updateQuality } from '../inventory/gilded_rose.js';
+import { Item, updateItems } from '../inventory/gilded_rose.js';
 
 const getNewItems = () => [
   new Item('+5 Dexterity Vest', 10, 20),
@@ -30,7 +30,7 @@ const bindEventListenToUpdateButton = (items) => {
   const updateButton = document.getElementById('update-items-button');
   updateButton.addEventListener('click', (e) => {
     e.preventDefault();
-    updateQuality(items);
+    updateItems(items);
     renderItemsOnHomepage(items);
   });
 };


### PR DESCRIPTION
## Description
Added tests, functionality for the item 'Conjured Mana Cake'. The README is a bit misleading, and only support for the "COnjured Mana Cake" needed to be added, not all "conjured" items.

## Spec

See Issue: [FSA22V2-78](https://sparkbox.atlassian.net/browse/FSA22V2-78)

### To Validate

1. Make sure all PR Checks have passed.
2. Make sure all tests, added and old, have passed.
